### PR TITLE
fix: include port when building redirect URL

### DIFF
--- a/src/main/java/com/github/binarywang/demo/wx/mp/controller/WxMenuController.java
+++ b/src/main/java/com/github/binarywang/demo/wx/mp/controller/WxMenuController.java
@@ -91,9 +91,10 @@ public class WxMenuController {
         if (servletRequestAttributes != null) {
             HttpServletRequest request = servletRequestAttributes.getRequest();
             URL requestURL = new URL(request.getRequestURL().toString());
+            String portPart = requestURL.getPort() == -1 ? "" : ":" + requestURL.getPort();
             String url = WxMpConfiguration.getMpServices().get(appid)
                 .oauth2buildAuthorizationUrl(
-                    String.format("%s://%s/wx/redirect/%s/greet", requestURL.getProtocol(), requestURL.getHost(), appid),
+                    String.format("%s://%s%s/wx/redirect/%s/greet", requestURL.getProtocol(), requestURL.getHost(), portPart, appid),
                     WxConsts.OAuth2Scope.SNSAPI_USERINFO, null);
             button34.setUrl(url);
         }


### PR DESCRIPTION
## Summary
- ensure port is included when generating OAuth redirect URL

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad78e32a1c8333924ac7044c11cac7